### PR TITLE
Fix load subtitles

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.42">
+<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.43">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
     <import addon="script.module.simplejson" version="2.0.10" />

--- a/lib/contentprovider/xbmcprovider.py
+++ b/lib/contentprovider/xbmcprovider.py
@@ -181,7 +181,7 @@ class XBMContentProvider(object):
                 if self.settings['subs'] == True:
                     xbmcutil.load_subtitles(stream['subs'], stream['headers'])
             else: # optional setting - plugin may not supply it
-                xbmcutil.load_subtitles(stream['subs'])
+                xbmcutil.load_subtitles(stream['subs'], stream['headers'])
 
     def _handle_exc(self,e):
         msg = e.message

--- a/lib/xbmcutil.py
+++ b/lib/xbmcutil.py
@@ -197,7 +197,7 @@ def save_to_file(url, file, headers=None):
         traceback.print_exc()
 
 
-def load_subtitles(url, headers):
+def load_subtitles(url, headers=None):
     if not (url == '' or url == None):
         local = xbmc.translatePath(__addon__.getAddonInfo('path')).decode('utf-8')
         c_local = compat_path(local)


### PR DESCRIPTION
Looks like I messed up some plugins with previous commits :(

```
marko@ kodi-czsk2 $grep -Ir load_subtitles|grep -v logs
plugin.video.mixer.cz/default.py:            xbmcutil.load_subtitles(stream['subs'])
plugin.video.rtvs.sk/default.py:            xbmcutil.load_subtitles(stream['subs'])
plugin.video.markiza.sk/default.py:            xbmcutil.load_subtitles(stream['subs'])
plugin.video.videacesky.cz/default.py:            xbmcutil.load_subtitles(stream['subs'])
.git/modules/script.module.stream.resolver/HEAD:ref: refs/heads/fix_load_subtitles
script.module.stream.resolver/lib/xbmcutil.py:def load_subtitles(url, headers=None):
script.module.stream.resolver/lib/contentprovider/xbmcprovider.py:                    xbmcutil.load_subtitles(stream['subs'], stream['headers'])
script.module.stream.resolver/lib/contentprovider/xbmcprovider.py:                xbmcutil.load_subtitles(stream['subs'], stream['headers'])
plugin.video.pohadkar.cz/default.py:            xbmcutil.load_subtitles(stream['subs'])
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kodi-czsk/script.module.stream.resolver/40)

<!-- Reviewable:end -->
