### PR TITLE
Added support for new listitem art handling in Jarvis

### DIFF
--- a/lib/contentprovider/xbmcprovider.py
+++ b/lib/contentprovider/xbmcprovider.py
@@ -176,6 +176,15 @@ class XBMContentProvider(object):
             il = self._extract_infolabels(item['info'])
             if len(il) > 0: #only set when something was extracted
                 li.setInfo('video',il)
+            # new art handling from Jarvis - begin
+            if 'art' in item['info'].keys():
+                if 'poster' in item['info']['art'].keys():
+                    # movie
+                    li.setArt({'thumb' :item['info']['art']['poster']})
+                elif 'thumb' in item['info']['art'].keys():
+                    # tv serie
+                    li.setArt({'thumb' :item['info']['art']['thumb']})
+            # new art handling from Jarvis - end
             xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, li)
             if 'subs' in self.settings.keys():
                 if self.settings['subs'] == True:


### PR DESCRIPTION
Z dokumentace:
Starting from 16.0 (Jarvis) all image-related parameters and methods will be depreciated  and `setArt` will become the only method for setting ListItem's images.
Úprava je potřebná pro funkčnost:  https://github.com/kodi-czsk/plugin.video.sosac.ph/pull/79

Pokud vyhovuje děkuji za merge.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kodi-czsk/script.module.stream.resolver/41)

<!-- Reviewable:end -->
