### PR TITLE
Fix error when "headers" key is missing

### DIFF
--- a/lib/contentprovider/xbmcprovider.py
+++ b/lib/contentprovider/xbmcprovider.py
@@ -179,9 +179,9 @@ class XBMContentProvider(object):
             xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, li)
             if 'subs' in self.settings.keys():
                 if self.settings['subs'] == True:
-                    xbmcutil.load_subtitles(stream['subs'], stream['headers'])
+                    xbmcutil.load_subtitles(stream['subs'], stream.get('headers'))
             else: # optional setting - plugin may not supply it
-                xbmcutil.load_subtitles(stream['subs'], stream['headers'])
+                xbmcutil.load_subtitles(stream['subs'], stream.get('headers'))
 
     def _handle_exc(self,e):
         msg = e.message


### PR DESCRIPTION
https://github.com/kodi-czsk/plugin.video.ta3.com/issues/3

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kodi-czsk/script.module.stream.resolver/42)

<!-- Reviewable:end -->
