### PR TITLE
support for filtering resolved streams by addon language setting

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.44">
+<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.45">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
     <import addon="script.module.simplejson" version="2.0.10" />

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+[B]1.6.45:[/B]
+- support for filtering by language (needs to be passed by addon as 'lang' setting)
 [B]1.6.40:[/B]
 - add on_init hook to ContentProvider
 - fix hqq & nahnoji parsers, added sk translations (jose1711)

--- a/lib/contentprovider/provider.py
+++ b/lib/contentprovider/provider.py
@@ -85,7 +85,7 @@ class ContentProvider(object):
         Returns empty video item - contains all required fields
         """
         return {'type': 'video', 'title': '', 'rating': 0, 'year': 0, 'size': '0MB', 'url': url, 'img': img,
-                'length': '', 'quality': quality, 'subs': '', 'surl': ''}
+                'length': '', 'quality': quality, 'subs': '', 'surl': '', 'lang': ''}
 
     def dir_item(self, title='', url='', type='dir'):
         """

--- a/lib/resolver.py
+++ b/lib/resolver.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 # *      Copyright (C) 2011 Libor Zoubek
 # *
 # *
@@ -226,6 +227,20 @@ def filter_by_quality(resolved, q):
         ret.reverse()
     return ret
 
+def filter_by_language(resolved, lang):
+    util.info('filtering by language setting ' + lang)
+    if lang == '0':
+        return resolved
+    ret = []
+    # first group streams by source url
+    for item in resolved:
+        if 'lang' in item and item['lang'] != '':
+            util.info(item)
+            if lang == '1' and re.match('en', item['lang'], re.IGNORECASE):
+                ret.append(item)
+            if lang == '2' and re.match('cs|cz|čeština', item['lang'], re.IGNORECASE):
+                ret.append(item)
+    return ret
 
 def findstreams_multi(data, regexes):
     """

--- a/lib/server/streamujtvresolver.py
+++ b/lib/server/streamujtvresolver.py
@@ -41,7 +41,7 @@ def resolve(url):
         for lang in languages:
             streams = re.search('res'+str(index)+'\:[^\"]*\"([^\"]+)',data,re.IGNORECASE|re.DOTALL)
             subs = re.search('sub'+str(index)+'\:[^\"]*\"([^\"]+)',data,re.IGNORECASE|re.DOTALL)
-            if subs: 
+            if subs:
                 subs = re.search('[^>]+>([^$]+)',subs.group(1),re.IGNORECASE|re.DOTALL)
             if streams and qualities:
                 streams = streams.group(1).split(',')
@@ -55,7 +55,7 @@ def resolve(url):
                         q = '720p'
                     else:
                         q = 'SD'
-                    l = ' '+lang
+                    l = ''+lang
                     if subs:
                         l += ' + subs'
                         s = subs.group(1)


### PR DESCRIPTION
Tato feature pridava moznost addonum vlozit 'lang' - jako preferovany jazyk videa.

 * 0 je bez preference (default)
 * 1 anglictina
 * 2 cestina

Pri autoselekci kvality se pak streamy filtruji i dle preference jazyka. Pokud nalezneme alespon jedno video v danem jazyku, dojde k automatickemu prehrani videa. Pokud resolvery nepodporuji jazyk, nebo neni nalezena shoda, musi uzivatel stream vybrat