### PR TITLE
Give up using simplejson

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -2,7 +2,6 @@
 <addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.50">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
-    <import addon="script.module.simplejson" version="2.0.10" />
     <import addon="script.common.plugin.cache" version="2.5.5"/>
     <import addon="script.module.demjson" version="2.2.3" />
     <import addon="script.module.beautifulsoup4" version="4.3.1"/>

--- a/lib/server/streamujtvresolver.py
+++ b/lib/server/streamujtvresolver.py
@@ -8,7 +8,7 @@
 # */
 import re
 import util
-import simplejson as json
+import json
 from base64 import b64decode, b64encode
 
 __name__ = 'streamujtv'

--- a/lib/server/youtuberesolver.py
+++ b/lib/server/youtuberesolver.py
@@ -173,7 +173,7 @@ decryptor = CVevoSignAlgoExtractor()
 import sys
 import urllib
 import cgi
-import simplejson as json
+import json
 
 
 class YoutubePlayer(object):

--- a/lib/usage/tracker.py
+++ b/lib/usage/tracker.py
@@ -19,7 +19,7 @@
 # *  http://www.gnu.org/copyleft/gpl.html
 # *
 # */
-import simplejson as json
+import json
 import xbmc
 import os
 import random

--- a/lib/util.py
+++ b/lib/util.py
@@ -31,7 +31,7 @@ import threading
 import Queue
 import pickle
 import string
-import simplejson as json
+import json
 from demjson import demjson
 from bs4 import BeautifulSoup
 import cloudflare

--- a/lib/xbmcutil.py
+++ b/lib/xbmcutil.py
@@ -34,7 +34,7 @@ import xbmcplugin
 import xbmc
 import xbmcaddon
 from htmlentitydefs import name2codepoint as n2cp
-import simplejson as json
+import json
 import util
 UA = 'Mozilla/6.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.5) Gecko/2008092417 Firefox/3.0.3'
 


### PR DESCRIPTION
simplejson was used in ancient versions of Kodi, which used Python
versions that did not include json module. All modern versions of
Kodi use Python 2.6 or newer, so using simplejson is no longer
necessary.

Fixes #56.