### PR TITLE
Recognize duration as infolabels attribute

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.54">
+<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.55">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
     <import addon="script.common.plugin.cache" version="2.5.5"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
-[B]1.6.53:[/B]
+[B]1.6.55:[/B]
+- duration is now recognized as infolabels attribute
+[B]1.6.54:[/B]
 - add dailymotion resolver
 [B]1.6.52:[/B]
 - fix streamujtv resolver

--- a/lib/contentprovider/xbmcprovider.py
+++ b/lib/contentprovider/xbmcprovider.py
@@ -273,7 +273,9 @@ class XBMContentProvider(object):
 
     def _extract_infolabels(self, item):
         infoLabels = {}
-        for label in ['title', 'plot', 'year', 'genre', 'rating', 'director', 'votes', 'cast', 'trailer', 'tvshowtitle', 'season', 'episode']:
+        for label in ['title', 'plot', 'year', 'genre', 'rating', 'director',
+                      'votes', 'cast', 'trailer', 'tvshowtitle', 'season',
+                      'episode', 'duration']:
             if label in item.keys():
                 infoLabels[label] = util.decode_html(item[label])
         return infoLabels


### PR DESCRIPTION
This change allows addons to list videos with
durations prior to playing them.