### PR TITLE
preserve compatibility with older kodi versions

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.57">
+<addon id="script.module.stream.resolver" name="Stream Resolver" provider-name="Libor Zoubek" version="1.6.58">
   <requires>
     <import addon="xbmc.python" version="2.1.0" />
     <import addon="script.common.plugin.cache" version="2.5.5"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+[B]1.6.58:[/B]
+- preserve compatibility with older kodi versions
 [B]1.6.57:[/B]
 - youtube: age content
 [B]1.6.56:[/B]

--- a/lib/contentprovider/xbmcprovider.py
+++ b/lib/contentprovider/xbmcprovider.py
@@ -195,8 +195,13 @@ class XBMContentProvider(object):
             il = self._extract_infolabels(item['info'])
             if len(il) > 0:  # only set when something was extracted
                 li.setInfo('video', il)
-            local_subs = xbmcutil.set_subtitles(li, stream['subs'], stream.get('headers'))
-            xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, li)
+            try:
+                local_subs = xbmcutil.set_subtitles(li, stream['subs'], stream.get('headers'))
+            except:
+                xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, li)
+                xbmcutil.load_subtitles(stream['subs'], stream.get('headers'))
+            else:
+                xbmcplugin.setResolvedUrl(int(sys.argv[1]), True, li)
 
     def _handle_exc(self, e):
         msg = e.message


### PR DESCRIPTION
04:48:53 T:836691040   ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.AttributeError'>
                                            Error Contents: 'xbmcgui.ListItem' object has no attribute 'setSubtitles'
                                            Traceback (most recent call last):
                                              File "/home/root/.xbmc/addons/plugin.video.sosac.ph/default.py", line 56, in <module>
                                                XBMCSosac(sosac, settings, __addon__).run(params)
                                              File "/home/root/.xbmc/addons/script.module.stream.resolver/lib/contentprovider/xbmcprovider.py", line 87, in run
                                                return self.play({'url': params['play'], 'info': params})
                                              File "/home/root/.xbmc/addons/script.module.stream.resolver/lib/contentprovider/xbmcprovider.py", line 198, in play
                                                local_subs = xbmcutil.set_subtitles(li, stream['subs'], stream.get('headers'))
                                              File "/home/root/.xbmc/addons/script.module.stream.resolver/lib/xbmcutil.py", line 218, in set_subtitles
                                                listItem.setSubtitles([local.encode('utf-8')])
                                            AttributeError: 'xbmcgui.ListItem' object has no attribute 'setSubtitles'
                                            -->End of Python script error report<--
